### PR TITLE
Support configuring per-lambda build flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ outDirectory: tmp
 # Optional, defaults to the name of the Lambda's directory.
 # zippedFileName: bootstrap
 
-# Additional build flags passed to "go build"
-# For example, if you want to provide extra compiler or linker options
-# Supports environment variable expansion: $VAR or ${VAR}
+# Additional build flags passed to "go build".
+# For example, if you want to provide extra compiler or linker options.
+# Supports environment variable expansion: $VAR or ${VAR}.
+# This serves as the default for all lambdas unless overridden per-lambda.
 # buildFlags: -tags extra,tags -ldflags="-linker -flags"
 
 # Allow overriding the GOOS and GOARCH environment variables to
@@ -52,15 +53,24 @@ outDirectory: tmp
 # goos: linux
 # goarch: amd64
 
+# Option 1: Simple paths
 # Paths to build into Lambda zip files.
 # Each path should contain a main package.
 # The artifacts are built to: <outDirectory>/<buildPath>.zip
 buildPaths:
   - lambdas/hello_world
+
+# Option 2: Per-lambda configuration with custom build flags.
+lambdas:
+  - path: lambdas/api
+    buildFlags: -tags prod -ldflags="-s -w"
+  - path: lambdas/worker
+    buildFlags: "" # Forces no flags, even if some are defined on the top-level option
+  - path: lambdas/simple
+    # Inherits top-level buildFlags if not specified
+
+# Both buildPaths and lambdas can be used together, but duplicate paths will result in an error.
 ```
-
-Using the above example file would cause `lambgo build` to build `lambdas/hello_world` to `tmp/lambdas/hello_world.zip`.
-
 
 ## Examples
 See the [`examples` directory](./examples) for examples.

--- a/internal/cmd/build_test.go
+++ b/internal/cmd/build_test.go
@@ -43,15 +43,23 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: 3,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"path1", "path2", "path3"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -65,15 +73,23 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: 1,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"path1", "path2", "path3"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -86,15 +102,23 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: 1,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"path1", "path2", "path3"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -108,15 +132,23 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"first/0", "abc/123", "xyz/456", "qwerty/789"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("first/0", nil),
+							makeLambda("abc/123", nil),
+							makeLambda("xyz/456", nil),
+							makeLambda("qwerty/789", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: 2,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"abc/123", "xyz/456"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("abc/123", nil),
+							makeLambda("xyz/456", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -130,15 +162,26 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"first/0", "abc/123", "xyz/456", "qwerty/789", "nested/one", "nested/two"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("first/0", nil),
+							makeLambda("abc/123", nil),
+							makeLambda("xyz/456", nil),
+							makeLambda("qwerty/789", nil),
+							makeLambda("nested/one", nil),
+							makeLambda("nested/two", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: 3,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"nested/one", "nested/two", "xyz/456"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("nested/one", nil),
+							makeLambda("nested/two", nil),
+							makeLambda("xyz/456", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -152,15 +195,23 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: 3,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"path1", "path2", "path3"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -173,15 +224,23 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: 2,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"path1", "path2", "path3"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -194,15 +253,135 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 
 				m.Builder.EXPECT().
 					BuildBinaries(&lambgofile.Config{
 						NumParallel: int(1.5 * float64(runtime.NumCPU())),
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"path1", "path2", "path3"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
+					}).
+					Return(nil)
+			},
+		},
+
+		{
+			Name:  "with valid execution: filter using --only flag with per-lambda buildFlags",
+			Flags: []string{"--only", "lambdas/api"},
+			Getwd: defaultWd,
+			SetupMocks: func(m *Mocks) {
+				m.LambgoFileLoader.EXPECT().
+					LoadConfig("/test").
+					Return(&lambgofile.Config{
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("lambdas/api", []string{"-tags", "prod"}),
+							makeLambda("lambdas/worker", []string{"-ldflags", "-s"}),
+							makeLambda("lambdas/simple", nil),
+						},
+					}, nil)
+
+				m.Builder.EXPECT().
+					BuildBinaries(&lambgofile.Config{
+						NumParallel: 1,
+						RootPath:    "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("lambdas/api", []string{"-tags", "prod"}),
+						},
+					}).
+					Return(nil)
+			},
+		},
+		{
+			Name:  "with valid execution: filter using --only flag with directory and mixed buildFlags",
+			Flags: []string{"--only", "lambdas/"},
+			Getwd: defaultWd,
+			SetupMocks: func(m *Mocks) {
+				m.LambgoFileLoader.EXPECT().
+					LoadConfig("/test").
+					Return(&lambgofile.Config{
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("lambdas/api", []string{"-tags", "prod"}),
+							makeLambda("lambdas/worker", []string{"-ldflags", "-s"}),
+							makeLambda("lambdas/simple", nil),
+							makeLambda("functions/other", []string{"-tags", "dev"}),
+						},
+					}, nil)
+
+				m.Builder.EXPECT().
+					BuildBinaries(&lambgofile.Config{
+						NumParallel: 3,
+						RootPath:    "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("lambdas/api", []string{"-tags", "prod"}),
+							makeLambda("lambdas/simple", nil),
+							makeLambda("lambdas/worker", []string{"-ldflags", "-s"}),
+						},
+					}).
+					Return(nil)
+			},
+		},
+		{
+			Name:  "with valid execution: filter multiple lambdas with different buildFlags",
+			Flags: []string{"--only", "lambdas/api", "--only", "functions/other"},
+			Getwd: defaultWd,
+			SetupMocks: func(m *Mocks) {
+				m.LambgoFileLoader.EXPECT().
+					LoadConfig("/test").
+					Return(&lambgofile.Config{
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+							makeLambda("lambdas/worker", nil),
+							makeLambda("functions/other", []string{"-tags", "dev"}),
+						},
+					}, nil)
+
+				m.Builder.EXPECT().
+					BuildBinaries(&lambgofile.Config{
+						NumParallel: 2,
+						RootPath:    "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("functions/other", []string{"-tags", "dev"}),
+							makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+						},
+					}).
+					Return(nil)
+			},
+		},
+		{
+			Name:  "with valid execution: filter preserves empty buildFlags override",
+			Flags: []string{"--only", "lambdas/worker"},
+			Getwd: defaultWd,
+			SetupMocks: func(m *Mocks) {
+				m.LambgoFileLoader.EXPECT().
+					LoadConfig("/test").
+					Return(&lambgofile.Config{
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("lambdas/api", []string{"-tags", "prod"}),
+							makeLambda("lambdas/worker", nil),
+						},
+					}, nil)
+
+				m.Builder.EXPECT().
+					BuildBinaries(&lambgofile.Config{
+						NumParallel: 1,
+						RootPath:    "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("lambdas/worker", nil),
+						},
 					}).
 					Return(nil)
 			},
@@ -234,7 +413,10 @@ func TestBuild(t *testing.T) {
 					Return(&lambgofile.Config{
 						NumParallel: 2,
 						RootPath:    "/some/root/path",
-						BuildPaths:  []string{"abc/123", "xyz/456"},
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("abc/123", nil),
+							makeLambda("xyz/456", nil),
+						},
 					}, nil)
 			},
 		},
@@ -248,8 +430,12 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 			},
 		},
@@ -262,8 +448,12 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 			},
 		},
@@ -276,8 +466,12 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 			},
 		},
@@ -290,8 +484,12 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 			},
 		},
@@ -304,8 +502,12 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 			},
 		},
@@ -318,8 +520,12 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 			},
 		},
@@ -332,8 +538,12 @@ func TestBuild(t *testing.T) {
 				m.LambgoFileLoader.EXPECT().
 					LoadConfig("/test").
 					Return(&lambgofile.Config{
-						RootPath:   "/some/root/path",
-						BuildPaths: []string{"path1", "path2", "path3"},
+						RootPath: "/some/root/path",
+						Lambdas: []*lambgofile.Lambda{
+							makeLambda("path1", nil),
+							makeLambda("path2", nil),
+							makeLambda("path3", nil),
+						},
 					}, nil)
 			},
 		},
@@ -365,4 +575,11 @@ func TestBuild(t *testing.T) {
 		err := entry.Subject.Run(append([]string{"lambgo", "build"}, entry.Flags...))
 		ensure(err).IsError(entry.ExpectedError)
 	})
+}
+
+func makeLambda(path string, buildFlags []string) *lambgofile.Lambda {
+	return &lambgofile.Lambda{
+		Path:       path,
+		BuildFlags: buildFlags,
+	}
 }

--- a/internal/lambgofile/lambgofile.go
+++ b/internal/lambgofile/lambgofile.go
@@ -24,9 +24,10 @@ outDirectory: tmp
 # Optional, defaults to the name of the Lambda's directory.
 # zippedFileName: bootstrap
 
-# Additional build flags passed to "go build"
-# For example, if you want to provide extra compiler or linker options
-# Supports environment variable expansion: $VAR or ${VAR}
+# Additional build flags passed to "go build".
+# For example, if you want to provide extra compiler or linker options.
+# Supports environment variable expansion: $VAR or ${VAR}.
+# This serves as the default for all lambdas unless overridden per-lambda.
 # buildFlags: -tags extra,tags -ldflags="-linker -flags"
 
 # Allow overriding the GOOS and GOARCH environment variables to
@@ -35,11 +36,23 @@ outDirectory: tmp
 # goos: linux
 # goarch: amd64
 
+# Option 1: Simple paths
 # Paths to build into Lambda zip files.
 # Each path should contain a main package.
 # The artifacts are built to: <outDirectory>/<buildPath>.zip
 buildPaths:
   - lambdas/hello_world
+
+# Option 2: Per-lambda configuration with custom build flags.
+lambdas:
+  - path: lambdas/api
+    buildFlags: -tags prod -ldflags="-s -w"
+  - path: lambdas/worker
+    buildFlags: "" # Forces no flags, even if some are defined on the top-level option
+  - path: lambdas/simple
+    # Inherits top-level buildFlags if not specified
+
+# Both buildPaths and lambdas can be used together, but duplicate paths will result in an error.
 `
 
 const (
@@ -50,11 +63,14 @@ const (
 type ErkCannotLoadConfig struct{ erk.DefaultKind }
 
 var (
-	ErrCannotFindGoModule  = erk.New(ErkCannotLoadConfig{}, "Cannot find root go.mod file by searching parent working directories")
-	ErrCannotParseGoModule = erk.New(ErkCannotLoadConfig{}, "Cannot read module path from go.mod file: {{.path}}")
-	ErrCannotOpenFile      = erk.New(ErkCannotLoadConfig{}, "Cannot open the file '{{.path}}': {{.err}}")
-	ErrCannotUnmarshalFile = erk.New(ErkCannotLoadConfig{}, "Cannot parse the file '{{.path}}': {{.err}}")
-	ErrCannotParseFlags    = erk.New(ErkCannotLoadConfig{}, "Cannot parse build flags '{{.flags}}': {{.err}}")
+	ErrCannotFindGoModule        = erk.New(ErkCannotLoadConfig{}, "Cannot find root go.mod file by searching parent working directories")
+	ErrCannotParseGoModule       = erk.New(ErkCannotLoadConfig{}, "Cannot read module path from go.mod file: {{.path}}")
+	ErrCannotOpenFile            = erk.New(ErkCannotLoadConfig{}, "Cannot open the file '{{.path}}': {{.err}}")
+	ErrCannotUnmarshalFile       = erk.New(ErkCannotLoadConfig{}, "Cannot parse the file '{{.path}}': {{.err}}")
+	ErrCannotParseFlags          = erk.New(ErkCannotLoadConfig{}, "Cannot parse build flags '{{.flags}}': {{.err}}")
+	ErrCannotParsePerLambdaFlags = erk.New(ErkCannotLoadConfig{}, "Cannot parse build flags for lambda '{{.path}}' with flags '{{.flags}}': {{.err}}")
+	ErrDuplicatePaths            = erk.New(ErkCannotLoadConfig{}, "Duplicate lambda paths found: {{.paths}}")
+	ErrEmptyLambdaPath           = erk.New(ErkCannotLoadConfig{}, "Lambda has an empty path")
 )
 
 type LoaderAPI interface {
@@ -68,19 +84,40 @@ type Loader struct {
 
 var _ LoaderAPI = &Loader{}
 
-// Config is the root of the .lambgo.yml file.
-type Config struct {
-	NumParallel int    `yaml:"-"`
-	RootPath    string `yaml:"-"`
-	ModulePath  string `yaml:"-"`
+// rawConfig is the internal struct used for unmarshaling from .lambgo.yml.
+// It contains all the YAML tags and raw fields that need processing.
+type rawConfig struct {
+	OutDirectory   string       `yaml:"outDirectory"`
+	ZippedFileName string       `yaml:"zippedFileName"`
+	RawBuildFlags  string       `yaml:"buildFlags"`
+	Goos           string       `yaml:"goos"`
+	Goarch         string       `yaml:"goarch"`
+	BuildPaths     []string     `yaml:"buildPaths"`
+	RawLambdas     []*rawLambda `yaml:"lambdas"`
+}
 
-	OutDirectory   string   `yaml:"outDirectory"`
-	ZippedFileName string   `yaml:"zippedFileName"`
-	RawBuildFlags  string   `yaml:"buildFlags"`
-	Goos           string   `yaml:"goos"`
-	Goarch         string   `yaml:"goarch"`
-	BuildFlags     []string `yaml:"-"`
-	BuildPaths     []string `yaml:"buildPaths"`
+// rawLambda is the internal struct used for unmarshaling lambda configurations.
+type rawLambda struct {
+	Path          string  `yaml:"path"`
+	RawBuildFlags *string `yaml:"buildFlags,omitempty"`
+}
+
+// Config is the root configuration after processing .lambgo.yml.
+type Config struct {
+	NumParallel    int
+	RootPath       string
+	ModulePath     string
+	OutDirectory   string
+	ZippedFileName string
+	Goos           string
+	Goarch         string
+	Lambdas        []*Lambda
+}
+
+// Lambda represents a single lambda function with its build configuration.
+type Lambda struct {
+	Path       string
+	BuildFlags []string
 }
 
 // LoadConfig from the .lambgo.yml file that is located in pwd or a parent of pwd.
@@ -111,6 +148,15 @@ func (l *Loader) LoadConfig(pwd string) (*Config, error) {
 		})
 	}
 
+	config, err := l.parseConfigFile(pwd, modulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func (l *Loader) parseConfigFile(pwd, modulePath string) (*Config, error) {
 	configFilePath := filepath.Join(pwd, configFileName)
 	configFileData, err := fs.ReadFile(l.FS, configFilePath)
 	if err != nil {
@@ -119,29 +165,126 @@ func (l *Loader) LoadConfig(pwd string) (*Config, error) {
 		})
 	}
 
-	config := Config{}
-	if err := yaml.Unmarshal(configFileData, &config); err != nil {
+	rawCfg := rawConfig{}
+	if err := yaml.Unmarshal(configFileData, &rawCfg); err != nil {
 		return nil, erk.WrapWith(ErrCannotUnmarshalFile, err, erk.Params{
 			"path": configFilePath,
 		})
 	}
 
-	if config.RawBuildFlags != "" {
-		buildFlags, err := shell.Fields(config.RawBuildFlags, os.Getenv)
-		if err != nil {
-			return nil, erk.WrapWith(ErrCannotParseFlags, err, erk.Params{
-				"flags": config.RawBuildFlags,
-			})
-		}
+	buildFlags, err := parseBuildFlags(rawCfg.RawBuildFlags)
+	if err != nil {
+		return nil, erk.WrapWith(ErrCannotParseFlags, err, erk.Params{
+			"flags": rawCfg.RawBuildFlags,
+		})
+	}
 
-		config.BuildFlags = buildFlags
+	lambdas, err := rawCfg.mergeLambdas(buildFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &Config{
+		RootPath:       "/" + pwd,
+		ModulePath:     modulePath,
+		OutDirectory:   rawCfg.OutDirectory,
+		ZippedFileName: rawCfg.ZippedFileName,
+		Goos:           rawCfg.Goos,
+		Goarch:         rawCfg.Goarch,
+		Lambdas:        lambdas,
 	}
 
 	config.setDefaults()
+	return config, nil
+}
 
-	config.RootPath = "/" + pwd
-	config.ModulePath = modulePath
-	return &config, nil
+func (raw *rawConfig) mergeLambdas(defaultBuildFlags []string) ([]*Lambda, error) {
+	lambdas := make([]*Lambda, 0, len(raw.BuildPaths)+len(raw.RawLambdas))
+
+	for _, buildPath := range raw.BuildPaths {
+		lambda, err := transformBuildPathToLambda(buildPath, defaultBuildFlags)
+		if err != nil {
+			return nil, err
+		}
+
+		lambdas = append(lambdas, lambda)
+	}
+
+	for _, rawLambda := range raw.RawLambdas {
+		lambda, err := rawLambda.transform(defaultBuildFlags)
+		if err != nil {
+			return nil, err
+		}
+
+		lambdas = append(lambdas, lambda)
+	}
+
+	seenPaths := make(map[string]struct{})
+	var duplicates []string
+	for _, lambda := range lambdas {
+		if _, exists := seenPaths[lambda.Path]; exists {
+			duplicates = append(duplicates, lambda.Path)
+		}
+		seenPaths[lambda.Path] = struct{}{}
+	}
+
+	if len(duplicates) > 0 {
+		return nil, erk.WithParams(ErrDuplicatePaths, erk.Params{
+			"paths": strings.Join(duplicates, ", "),
+		})
+	}
+
+	return lambdas, nil
+}
+
+func transformBuildPathToLambda(buildPath string, defaultBuildFlags []string) (*Lambda, error) {
+	if buildPath == "" {
+		return nil, ErrEmptyLambdaPath
+	}
+
+	normalizedPath := filepath.Clean(buildPath)
+	return &Lambda{
+		Path:       normalizedPath,
+		BuildFlags: defaultBuildFlags,
+	}, nil
+}
+
+func (rawLambda *rawLambda) transform(defaultBuildFlags []string) (*Lambda, error) {
+	if rawLambda.Path == "" {
+		return nil, ErrEmptyLambdaPath
+	}
+
+	normalizedPath := filepath.Clean(rawLambda.Path)
+	lambda := &Lambda{Path: normalizedPath}
+
+	if rawLambda.RawBuildFlags == nil {
+		lambda.BuildFlags = defaultBuildFlags
+	} else {
+		buildFlags, err := parseBuildFlags(*rawLambda.RawBuildFlags)
+		if err != nil {
+			return nil, erk.WrapWith(ErrCannotParsePerLambdaFlags, err, erk.Params{
+				"path":  rawLambda.Path,
+				"flags": *rawLambda.RawBuildFlags,
+			})
+		}
+
+		lambda.BuildFlags = buildFlags
+	}
+
+	return lambda, nil
+}
+
+func parseBuildFlags(rawFlags string) ([]string, error) {
+	if rawFlags == "" {
+		return nil, nil
+	}
+
+	buildFlags, err := shell.Fields(rawFlags, os.Getenv)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildFlags, nil
 }
 
 func (config *Config) setDefaults() {

--- a/internal/lambgofile/lambgofile_test.go
+++ b/internal/lambgofile/lambgofile_test.go
@@ -21,7 +21,7 @@ func TestLoadConfig(t *testing.T) {
 		FS *mock_fs.MockReadFileFS
 	}
 
-	type mapFS map[string]interface{}
+	type mapFS map[string]any
 	setupMapFS := func(mapFS mapFS) func(*Mocks) {
 		return func(m *Mocks) {
 			m.FS.EXPECT().ReadFile(gomock.Any()).AnyTimes().
@@ -67,7 +67,12 @@ func TestLoadConfig(t *testing.T) {
 				OutDirectory: "tmp",
 				Goos:         "linux",
 				Goarch:       "amd64",
-				BuildPaths:   []string{"lambdas/hello_world"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", nil),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", nil),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -87,7 +92,12 @@ func TestLoadConfig(t *testing.T) {
 				OutDirectory: "tmp",
 				Goos:         "linux",
 				Goarch:       "amd64",
-				BuildPaths:   []string{"lambdas/hello_world"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", nil),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", nil),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -108,7 +118,12 @@ func TestLoadConfig(t *testing.T) {
 				OutDirectory:   "tmp",
 				Goos:           "linux",
 				Goarch:         "amd64",
-				BuildPaths:     []string{"lambdas/hello_world"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", nil),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", nil),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -125,14 +140,17 @@ zippedFileName: some-name
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-foo -bar "baz qux"`,
-				BuildFlags:    []string{"-foo", "-bar", "baz qux"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-foo", "-bar", "baz qux"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-foo", "-bar", "baz qux"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -149,14 +167,17 @@ buildFlags: -foo -bar "baz qux"
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag ""`,
-				BuildFlags:    []string{"-flag", ""},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag", ""}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag", ""}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -173,14 +194,17 @@ buildFlags: -flag ""
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag 'value with spaces'`,
-				BuildFlags:    []string{"-flag", "value with spaces"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag", "value with spaces"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag", "value with spaces"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -197,14 +221,17 @@ buildFlags: -flag 'value with spaces'
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag "value with \"nested\" quotes"`,
-				BuildFlags:    []string{"-flag", `value with "nested" quotes`},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag", `value with "nested" quotes`}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag", `value with "nested" quotes`}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -221,14 +248,17 @@ buildFlags: -flag "value with \"nested\" quotes"
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag    value    -other`,
-				BuildFlags:    []string{"-flag", "value", "-other"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag", "value", "-other"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag", "value", "-other"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -245,14 +275,17 @@ buildFlags: -flag    value    -other
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-ldflags="-X main.version=1.0.0" -tags=prod,dev`,
-				BuildFlags:    []string{"-ldflags=-X main.version=1.0.0", "-tags=prod,dev"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-ldflags=-X main.version=1.0.0", "-tags=prod,dev"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags=-X main.version=1.0.0", "-tags=prod,dev"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -269,14 +302,17 @@ buildFlags: -ldflags="-X main.version=1.0.0" -tags=prod,dev
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag1 "double quotes" -flag2 'single quotes'`,
-				BuildFlags:    []string{"-flag1", "double quotes", "-flag2", "single quotes"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag1", "double quotes", "-flag2", "single quotes"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag1", "double quotes", "-flag2", "single quotes"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -293,14 +329,17 @@ buildFlags: -flag1 "double quotes" -flag2 'single quotes'
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-ldflags "-X main.version=$UNDEFINED_VAR" -tags $ALSO_UNDEFINED`,
-				BuildFlags:    []string{"-ldflags", "-X main.version=", "-tags"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-ldflags", "-X main.version=", "-tags"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags", "-X main.version=", "-tags"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -317,14 +356,17 @@ buildFlags: -ldflags "-X main.version=$UNDEFINED_VAR" -tags $ALSO_UNDEFINED
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-ldflags "-X main.version=\$VERSION" -tags \$BUILD_TAGS`,
-				BuildFlags:    []string{"-ldflags", "-X main.version=$VERSION", "-tags", "$BUILD_TAGS"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-ldflags", "-X main.version=$VERSION", "-tags", "$BUILD_TAGS"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags", "-X main.version=$VERSION", "-tags", "$BUILD_TAGS"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -341,14 +383,17 @@ buildFlags: -ldflags "-X main.version=\$VERSION" -tags \$BUILD_TAGS
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag value`,
-				BuildFlags:    []string{"-flag", "value"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag", "value"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag", "value"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -365,14 +410,17 @@ buildFlags:   -flag value
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag value\ with\ spaces`,
-				BuildFlags:    []string{"-flag", "value with spaces"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag", "value with spaces"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag", "value with spaces"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -389,14 +437,17 @@ buildFlags: -flag value\ with\ spaces
 			PWD: "/my/app",
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-tags netgo,osusergo -ldflags="-s -w -X main.version=v1.2.3"`,
-				BuildFlags:    []string{"-tags", "netgo,osusergo", "-ldflags=-s -w -X main.version=v1.2.3"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-tags", "netgo,osusergo", "-ldflags=-s -w -X main.version=v1.2.3"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-tags", "netgo,osusergo", "-ldflags=-s -w -X main.version=v1.2.3"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -416,14 +467,17 @@ buildFlags: -tags netgo,osusergo -ldflags="-s -w -X main.version=v1.2.3"
 			},
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-ldflags "-X main.version=$VERSION"`,
-				BuildFlags:    []string{"-ldflags", "-X main.version=v1.2.3"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-ldflags", "-X main.version=v1.2.3"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags", "-X main.version=v1.2.3"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -445,14 +499,17 @@ buildFlags: -ldflags "-X main.version=$VERSION"
 			},
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-ldflags "-X main.version=$VERSION -X main.commit=$GIT_COMMIT" -tags $BUILD_TAGS`,
-				BuildFlags:    []string{"-ldflags", "-X main.version=v2.0.0 -X main.commit=abc123", "-tags", "prod,netgo"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-ldflags", "-X main.version=v2.0.0 -X main.commit=abc123", "-tags", "prod,netgo"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags", "-X main.version=v2.0.0 -X main.commit=abc123", "-tags", "prod,netgo"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -472,14 +529,17 @@ buildFlags: -ldflags "-X main.version=$VERSION -X main.commit=$GIT_COMMIT" -tags
 			},
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-ldflags "-X main.version=${VERSION}"`,
-				BuildFlags:    []string{"-ldflags", "-X main.version=v3.0.0"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-ldflags", "-X main.version=v3.0.0"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags", "-X main.version=v3.0.0"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -500,14 +560,17 @@ buildFlags: -ldflags "-X main.version=${VERSION}"
 			},
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-flag1=${VAR1:-default1} -flag2=${VAR2:-default2}`,
-				BuildFlags:    []string{"-flag1=set", "-flag2=default2"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-flag1=set", "-flag2=default2"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-flag1=set", "-flag2=default2"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -528,14 +591,17 @@ buildFlags: -flag1=${VAR1:-default1} -flag2=${VAR2:-default2}
 			},
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-tags netgo -ldflags "-X main.version=$VERSION -X main.literal=\$LITERAL"`,
-				BuildFlags:    []string{"-tags", "netgo", "-ldflags", "-X main.version=v1.0.0 -X main.literal=$LITERAL"},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-tags", "netgo", "-ldflags", "-X main.version=v1.0.0 -X main.literal=$LITERAL"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-tags", "netgo", "-ldflags", "-X main.version=v1.0.0 -X main.literal=$LITERAL"}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -555,14 +621,17 @@ buildFlags: -tags netgo -ldflags "-X main.version=$VERSION -X main.literal=\$LIT
 			},
 
 			ExpectedConfig: &lambgofile.Config{
-				RootPath:      "/my/app",
-				ModulePath:    "github.com/my/app",
-				RawBuildFlags: `-ldflags "-X main.set=$SET_VAR -X main.unset=$UNSET_VAR"`,
-				BuildFlags:    []string{"-ldflags", "-X main.set=set_value -X main.unset="},
-				OutDirectory:  "tmp",
-				Goos:          "linux",
-				Goarch:        "amd64",
-				BuildPaths:    []string{"lambdas/hello_world"},
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", []string{"-ldflags", "-X main.set=set_value -X main.unset="}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags", "-X main.set=set_value -X main.unset="}),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -584,7 +653,12 @@ buildFlags: -ldflags "-X main.set=$SET_VAR -X main.unset=$UNSET_VAR"
 				OutDirectory: "tmp",
 				Goos:         "plan9",
 				Goarch:       "amd64",
-				BuildPaths:   []string{"lambdas/hello_world"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", nil),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", nil),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -605,7 +679,12 @@ goos: plan9
 				OutDirectory: "tmp",
 				Goos:         "linux",
 				Goarch:       "arm64",
-				BuildPaths:   []string{"lambdas/hello_world"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", nil),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", nil),
+				},
 			},
 
 			SetupMocks: setupMapFS(mapFS{
@@ -627,7 +706,11 @@ goarch: arm64
 				OutDirectory: "tmp",
 				Goos:         "linux",
 				Goarch:       "amd64",
-				BuildPaths:   []string{"lambdas/hello_world", "lambdas/goodbye_world", "functions/my_function"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/hello_world", nil),
+					makeLambda("lambdas/goodbye_world", nil),
+					makeLambda("functions/my_function", nil),
+				},
 			},
 			SetupMocks: setupMapFS(mapFS{
 				"my/app/go.mod": defaultGoModFile,
@@ -642,20 +725,229 @@ buildPaths:
 		},
 
 		{
+			Name: "with valid config using lambdas field only",
+
+			PWD: "/my/app",
+
+			ExpectedConfig: &lambgofile.Config{
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/api", nil),
+					makeLambda("lambdas/worker", nil),
+				},
+			},
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: lambdas/api
+  - path: lambdas/worker
+`,
+			}),
+		},
+
+		{
+			Name: "with lambdas field having custom buildFlags",
+
+			PWD: "/my/app",
+
+			ExpectedConfig: &lambgofile.Config{
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/api", []string{"-tags", "prod"}),
+					makeLambda("lambdas/worker", []string{"-ldflags=-s -w"}),
+				},
+			},
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildFlags: -ldflags="-s -w"
+lambdas:
+  - path: lambdas/api
+    buildFlags: -tags prod
+  - path: lambdas/worker
+`,
+			}),
+		},
+
+		{
+			Name: "with lambdas field having empty buildFlags",
+
+			PWD: "/my/app",
+
+			ExpectedConfig: &lambgofile.Config{
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/api", nil)},
+			},
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildFlags: -ldflags="-s -w"
+lambdas:
+  - path: lambdas/api
+    buildFlags: ""
+`,
+			}),
+		},
+
+		{
+			Name: "with both buildPaths and lambdas fields",
+
+			PWD: "/my/app",
+
+			ExpectedConfig: &lambgofile.Config{
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/legacy", nil),
+					makeLambda("lambdas/api", nil),
+				},
+			},
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - lambdas/legacy
+lambdas:
+  - path: lambdas/api
+`,
+			}),
+		},
+
+		{
+			Name: "with lambdas field with environment variable expansion",
+
+			PWD: "/my/app",
+			EnvVars: map[string]string{
+				"VERSION": "v1.0.0",
+			},
+
+			ExpectedConfig: &lambgofile.Config{
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/api", []string{"-ldflags", "-X main.version=v1.0.0"})},
+			},
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: lambdas/api
+    buildFlags: -ldflags "-X main.version=$VERSION"
+`,
+			}),
+		},
+
+		{
+			Name: "with lambdas field with complex buildFlags",
+
+			PWD: "/my/app",
+
+			ExpectedConfig: &lambgofile.Config{
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/api", []string{"-tags", "netgo,osusergo", "-ldflags=-s -w -X main.version=v1.2.3"})},
+			},
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: lambdas/api
+    buildFlags: -tags netgo,osusergo -ldflags="-s -w -X main.version=v1.2.3"
+`,
+			}),
+		},
+
+		{
+			Name: "with multiple lambdas with mixed buildFlags scenarios",
+
+			PWD: "/my/app",
+
+			ExpectedConfig: &lambgofile.Config{
+				RootPath:     "/my/app",
+				ModulePath:   "github.com/my/app",
+				OutDirectory: "tmp",
+				Goos:         "linux",
+				Goarch:       "amd64",
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/api", []string{"-tags", "prod"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags=-s -w"}),
+				},
+			},
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildFlags: -ldflags="-s -w"
+lambdas:
+  - path: lambdas/api
+    buildFlags: -tags prod
+  - path: lambdas/worker
+    buildFlags: ""
+  - path: lambdas/simple
+`,
+			}),
+		},
+
+		{
 			Name: "with complex config including all fields and comments",
 
 			PWD: "/my/app",
+			EnvVars: map[string]string{
+				"VERSION":    "v2.0.0",
+				"GIT_COMMIT": "abc123",
+			},
 
 			ExpectedConfig: &lambgofile.Config{
 				RootPath:       "/my/app",
 				ModulePath:     "github.com/my/app",
 				OutDirectory:   "build",
 				ZippedFileName: "bootstrap",
-				RawBuildFlags:  `-tags prod -ldflags="-s -w"`,
-				BuildFlags:     []string{"-tags", "prod", "-ldflags=-s -w"},
 				Goos:           "linux",
 				Goarch:         "arm64",
-				BuildPaths:     []string{"lambdas/api", "lambdas/worker"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/legacy", []string{"-ldflags=-s -w"}),
+					makeLambda("lambdas/api", []string{"-tags", "prod", "-ldflags=-s -w -X main.version=v2.0.0 -X main.commit=abc123"}),
+					makeLambda("lambdas/worker", nil),
+					makeLambda("lambdas/simple", []string{"-ldflags=-s -w"}),
+				},
 			},
 			SetupMocks: setupMapFS(mapFS{
 				"my/app/go.mod": defaultGoModFile,
@@ -667,7 +959,7 @@ outDirectory: build
 zippedFileName: bootstrap
 
 # Build flags for production
-buildFlags: -tags prod -ldflags="-s -w"
+buildFlags: -ldflags="-s -w"
 
 # Target ARM64 architecture
 goos: linux
@@ -675,13 +967,16 @@ goarch: arm64
 
 # Lambda functions to build
 buildPaths:
-  - lambdas/api
-  - lambdas/worker
+  - lambdas/legacy
+lambdas:
+  - path: lambdas/api
+    buildFlags: -tags prod -ldflags="-s -w -X main.version=$VERSION -X main.commit=$GIT_COMMIT"
+  - path: lambdas/worker
+    buildFlags: ""
+  - path: lambdas/simple
 `,
 			}),
-		},
-
-		{
+		}, {
 			Name: "with various whitespace and formatting",
 
 			PWD: "/my/app",
@@ -692,7 +987,10 @@ buildPaths:
 				OutDirectory: "output",
 				Goos:         "linux",
 				Goarch:       "amd64",
-				BuildPaths:   []string{"lambdas/func1", "lambdas/func2"},
+				Lambdas: []*lambgofile.Lambda{
+					makeLambda("lambdas/func1", nil),
+					makeLambda("lambdas/func2", nil),
+				},
 			},
 			SetupMocks: setupMapFS(mapFS{
 				"my/app/go.mod": defaultGoModFile,
@@ -791,6 +1089,234 @@ buildPaths:
 				"my/app/.lambgo.yml": "buildFlags: foo'",
 			}),
 		},
+
+		{
+			Name: "when duplicate path between buildPaths and lambdas",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - lambdas/duplicate
+lambdas:
+  - path: lambdas/duplicate
+`,
+			}),
+		},
+
+		{
+			Name: "when duplicate path within lambdas array",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: lambdas/duplicate
+  - path: lambdas/duplicate
+`,
+			}),
+		},
+
+		{
+			Name: "when duplicate path within buildPaths array",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - lambdas/duplicate
+  - lambdas/duplicate
+`,
+			}),
+		},
+
+		{
+			Name: "when multiple duplicate paths",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - lambdas/dup1
+  - lambdas/dup1
+  - lambdas/dup2
+lambdas:
+  - path: lambdas/dup2
+`,
+			}),
+		},
+
+		{
+			Name: "when paths differ only by leading ./",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - lambdas/hello_world
+  - ./lambdas/hello_world
+`,
+			}),
+		},
+
+		{
+			Name: "when paths differ only by trailing /",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - lambdas/hello_world
+  - lambdas/hello_world/
+`,
+			}),
+		},
+
+		{
+			Name: "when paths have multiple variations that normalize to same path",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - ./lambdas/api
+  - lambdas/api/
+lambdas:
+  - path: lambdas/api
+`,
+			}),
+		},
+
+		{
+			Name: "when buildPath is empty",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrEmptyLambdaPath,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+buildPaths:
+  - ""
+`,
+			}),
+		},
+
+		{
+			Name: "when lambda has empty path",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrEmptyLambdaPath,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: ""
+    buildFlags: -tags prod
+`,
+			}),
+		},
+
+		{
+			Name: "when lambdas section has paths with leading ./ that normalize to same path",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: lambdas/api
+    buildFlags: -tags prod
+  - path: ./lambdas/api
+    buildFlags: -tags dev
+`,
+			}),
+		},
+
+		{
+			Name: "when lambdas section has paths with trailing / that normalize to same path",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrDuplicatePaths,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: lambdas/worker
+  - path: lambdas/worker/
+    buildFlags: ""
+`,
+			}),
+		},
+
+		{
+			Name: "when lambda has missing path field",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrEmptyLambdaPath,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - buildFlags: -tags prod
+`,
+			}),
+		},
+
+		{
+			Name: "when per-lambda buildFlags has invalid syntax",
+
+			PWD:           "/my/app",
+			ExpectedError: lambgofile.ErrCannotParsePerLambdaFlags,
+
+			SetupMocks: setupMapFS(mapFS{
+				"my/app/go.mod": defaultGoModFile,
+				"my/app/.lambgo.yml": `
+outDirectory: tmp
+lambdas:
+  - path: lambdas/api
+    buildFlags: foo'
+`,
+			}),
+		},
 	}
 
 	ensure.RunTableByIndex(table, func(ensure ensuring.E, i int) {
@@ -804,4 +1330,11 @@ buildPaths:
 		ensure(err).IsError(entry.ExpectedError)
 		ensure(config).Equals(entry.ExpectedConfig)
 	})
+}
+
+func makeLambda(path string, buildFlags []string) *lambgofile.Lambda {
+	return &lambgofile.Lambda{
+		Path:       path,
+		BuildFlags: buildFlags,
+	}
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Support per-lambda build flags configuration via new `lambdas` field

- Refactor config structure from `BuildPaths` string array to `Lambdas` struct array

- Each lambda can now override top-level `buildFlags` with custom per-lambda flags

- Maintain backward compatibility with existing `buildPaths` configuration

- Add validation for duplicate paths and empty lambda paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config File<br/>buildPaths + lambdas"] --> B["Parse & Merge<br/>Lambdas"]
  B --> C["Validate<br/>Duplicates"]
  C --> D["Lambda Array<br/>with BuildFlags"]
  D --> E["Build Each Lambda<br/>with Custom Flags"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambgofile.go</strong><dd><code>Refactor config to support per-lambda build flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/lambgofile/lambgofile.go

<ul><li>Introduce <code>Lambda</code> struct with <code>Path</code> and <code>BuildFlags</code> fields<br> <li> Create <code>rawConfig</code> and <code>rawLambda</code> internal structs for YAML unmarshaling<br> <li> Implement <code>mergeLambdas()</code> to combine <code>buildPaths</code> and <code>lambdas</code> <br>configurations<br> <li> Add validation for duplicate paths and empty lambda paths<br> <li> Parse per-lambda build flags with environment variable expansion <br>support</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-a25b96da7bf617af868a484f18c67e4f06b472c9fb9c55a0a12e28778fd7c457">+171/-28</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>builder.go</strong><dd><code>Update builder to use per-lambda configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/builder/builder.go

<ul><li>Replace <code>config.BuildPaths</code> string array with <code>config.Lambdas</code> struct <br>array<br> <li> Update <code>builderParams</code> to use <code>lambda *lambgofile.Lambda</code> instead of <br><code>buildPath</code> string<br> <li> Apply per-lambda <code>BuildFlags</code> from <code>lambda.BuildFlags</code> instead of global <br>config<br> <li> Update all logging and error handling to use <code>lambda.Path</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-38470f4364cc41382de32fdc999bfa165543c15ae246c08ff4a805405bdd5ee5">+20/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build.go</strong><dd><code>Refactor build command to handle Lambda structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/cmd/build.go

<ul><li>Extract build action logic into separate <code>runBuild()</code> function<br> <li> Rename <code>filterBuildPaths()</code> to <code>filterLambdas()</code> to work with Lambda <br>structs<br> <li> Add <code>extractLambdaPaths()</code> helper function for error reporting<br> <li> Update <code>parseNumParallel()</code> to use <code>config.Lambdas</code> length<br> <li> Replace <code>sort.Strings()</code> with <code>slices.SortFunc()</code> for Lambda sorting</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-f4ca56dd90f291b19991f9c7eb5a9595aab3d1d62b8f0c6e51ea7fd450f5b9fe">+56/-43</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>builder_test.go</strong><dd><code>Update builder tests for Lambda struct configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/builder/builder_test.go

<ul><li>Update all test cases to use <code>Lambdas</code> field with Lambda structs<br> <li> Add new test case for per-lambda custom <code>buildFlags</code><br> <li> Replace <code>BuildPaths</code> string slices with <code>[]*lambgofile.Lambda</code> arrays<br> <li> Verify that different lambdas can have different build flags applied</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-08a97f77c8b89bdcdd8691dbdbc6fa0ce1c22200af51e68e51e70741dd1dc5f1">+87/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_test.go</strong><dd><code>Update build command tests for Lambda configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/cmd/build_test.go

<ul><li>Update all test configurations to use <code>Lambdas</code> field<br> <li> Add helper function <code>makeLambda()</code> for test setup<br> <li> Add comprehensive test cases for per-lambda <code>buildFlags</code> filtering<br> <li> Test filtering with mixed <code>buildFlags</code> scenarios and directory filters<br> <li> Verify <code>buildFlags</code> are preserved during filtering operations</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-b96d3e7c4b3a8d08d870103ae748521528448cc90a936508c5682c3f6cdf5286">+256/-39</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lambgofile_test.go</strong><dd><code>Add comprehensive tests for per-lambda configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/lambgofile/lambgofile_test.go

<ul><li>Update all existing test cases to expect <code>Lambdas</code> struct array<br> <li> Add 20+ new test cases for per-lambda <code>buildFlags</code> functionality<br> <li> Test duplicate path detection across <code>buildPaths</code> and <code>lambdas</code><br> <li> Test empty path validation and complex real-world scenarios<br> <li> Test environment variable expansion in per-lambda <code>buildFlags</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-e356a80a32c301da3dc6b9dabbca04596f30f03d16b776321925e8955c5b93a8">+723/-155</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambgofile.go</strong><dd><code>Update example configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/lambgofile/lambgofile.go

<ul><li>Update example YAML configuration to show both <code>buildPaths</code> and <code>lambdas</code> <br>options<br> <li> Document that <code>buildFlags</code> serves as default for all lambdas<br> <li> Add documentation for per-lambda <code>buildFlags</code> override capability<br> <li> Clarify that both fields can be used together with duplicate detection</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-a25b96da7bf617af868a484f18c67e4f06b472c9fb9c55a0a12e28778fd7c457">+171/-28</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document per-lambda build flags feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add documentation for new <code>lambdas</code> configuration option<br> <li> Show example of per-lambda <code>buildFlags</code> with override and inheritance<br> <li> Clarify that <code>buildPaths</code> and <code>lambdas</code> can be used together<br> <li> Document duplicate path error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/lambgo/pull/25/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


[TODO.md](https://github.com/user-attachments/files/23571477/TODO.md)

